### PR TITLE
Fix path to malloc library in Mac OS

### DIFF
--- a/oaes_lib.c
+++ b/oaes_lib.c
@@ -34,7 +34,11 @@
 #include <stddef.h>
 #include <time.h> 
 #include <sys/timeb.h>
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#else
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Fix path to the malloc.h library and implements in Mac OS